### PR TITLE
Allow custom BPMN filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 - リポジトリ直下に `allocation-auto.bpmn20.xml` があれば **自動ロード**
 - キーボードショートカット (Delete, Ctrl/Cmd+Z など) 標準サポート
 
+> TIP: **Save BPMN** では任意のファイル名を入力できるため、`allocation-auto.bpmn20.xml` を1から作成可能です。
+
 ## デモ
 
 ```
@@ -30,7 +32,7 @@ $ python -m http.server 8080
 | ------------------- | ---------------------------------------- |
 | 📂 **ファイル選択** | `.bpmn` / `.xml` を読み込み              |
 | ➕ **New Diagram**  | 空の BPMN 図を生成                       |
-| 💾 **Save BPMN**    | 編集結果を `diagram.bpmn` でダウンロード |
+| 💾 **Save BPMN**    | ファイル名を指定して BPMN をダウンロード |
 | 🖼 **Save SVG**      | SVG 画像をダウンロード                   |
 
 > TIP: `#canvas` にファイルをドラッグ & ドロップしても読み込めます。

--- a/USAGE.md
+++ b/USAGE.md
@@ -19,7 +19,7 @@
 - **New Diagram** ボタンを押すと空の BPMN 図を生成します。
 
 ## 保存
-- **Save BPMN** で編集結果を `diagram.bpmn` としてダウンロードします。
+- **Save BPMN** を押すとファイル名を指定して BPMN を保存できます。
 - **Save SVG** で BPMN 図のプレビュー画像 (SVG) をダウンロードします。
 
 ## 編集のポイント

--- a/index.html
+++ b/index.html
@@ -103,7 +103,9 @@
       document.getElementById('btn-download-xml').addEventListener('click', async () => {
         try {
           const { xml } = await bpmnModeler.saveXML({ format: true });
-          downloadFile(xml, 'diagram.bpmn', 'application/bpmn20-xml');
+          const name =
+            prompt('File name to save as?', 'diagram.bpmn') || 'diagram.bpmn';
+          downloadFile(xml, name, 'application/bpmn20-xml');
         } catch (err) {
           console.error('❌ XML save error:', err);
         }


### PR DESCRIPTION
## Summary
- prompt for file name when saving BPMN so you can name it `allocation-auto.bpmn20.xml`
- update README/USAGE about the save behavior

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a27c6ef448333b5fb158b6e919775