### PR TITLE
Add new allocation template button

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ $ python -m http.server 8080
 | ------------------- | ---------------------------------------- |
 | 📂 **ファイル選択** | `.bpmn` / `.xml` を読み込み              |
 | ➕ **New Diagram**  | 空の BPMN 図を生成                       |
+| ➕ **New allocation-auto.bpmn20.xml** | 空図を生成し保存名を `allocation-auto.bpmn20.xml` に設定 |
 | 💾 **Save BPMN**    | ファイル名を指定して BPMN をダウンロード |
 | 🖼 **Save SVG**      | SVG 画像をダウンロード                   |
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -17,6 +17,7 @@
 
 ## 新規作成
 - **New Diagram** ボタンを押すと空の BPMN 図を生成します。
+- **New allocation-auto.bpmn20.xml** ボタンでは保存名を `allocation-auto.bpmn20.xml` に固定した空図を作成できます。
 
 ## 保存
 - **Save BPMN** を押すとファイル名を指定して BPMN を保存できます。

--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
     <div id="toolbar">
       <input type="file" id="file-input" accept=".bpmn,.xml" />
       <button id="btn-new">New Diagram</button>
+      <button id="btn-new-allocation">New allocation-auto.bpmn20.xml</button>
       <button id="btn-download-xml">Save BPMN</button>
       <button id="btn-download-svg">Save SVG</button>
     </div>
@@ -68,6 +69,7 @@
           bindTo: window,
         },
       });
+      let currentFilename = 'diagram.bpmn';
 
       // ===== 基本ユーティリティ =====
       const fitViewport = () => {
@@ -89,6 +91,7 @@
       document.getElementById('file-input').addEventListener('change', async (e) => {
         const file = e.target.files[0];
         if (!file) return;
+        currentFilename = file.name;
         const text = await file.text();
         await loadDiagram(text);
       });
@@ -96,15 +99,25 @@
       // ===== 新規作成 =====
       document.getElementById('btn-new').addEventListener('click', async () => {
         await bpmnModeler.createDiagram();
+        currentFilename = 'diagram.bpmn';
         fitViewport();
       });
+
+      document
+        .getElementById('btn-new-allocation')
+        .addEventListener('click', async () => {
+          await bpmnModeler.createDiagram();
+          currentFilename = 'allocation-auto.bpmn20.xml';
+          fitViewport();
+        });
 
       // ===== 保存：XML =====
       document.getElementById('btn-download-xml').addEventListener('click', async () => {
         try {
           const { xml } = await bpmnModeler.saveXML({ format: true });
           const name =
-            prompt('File name to save as?', 'diagram.bpmn') || 'diagram.bpmn';
+            prompt('File name to save as?', currentFilename) || currentFilename;
+          currentFilename = name;
           downloadFile(xml, name, 'application/bpmn20-xml');
         } catch (err) {
           console.error('❌ XML save error:', err);
@@ -141,6 +154,7 @@
         e.preventDefault();
         const file = e.dataTransfer.files[0];
         if (file) {
+          currentFilename = file.name;
           const text = await file.text();
           await loadDiagram(text);
         }
@@ -149,10 +163,14 @@
       // ===== 初期ロード：allocation-auto.bpmn20.xml が隣にあれば自動読込 =====
       fetch('allocation-auto.bpmn20.xml')
         .then((r) => (r.ok ? r.text() : Promise.reject(r)))
-        .then((xml) => loadDiagram(xml))
+        .then((xml) => {
+          currentFilename = 'allocation-auto.bpmn20.xml';
+          loadDiagram(xml);
+        })
         .catch(() => {
           // ファイルが見つからない場合は空図を作成
           bpmnModeler.createDiagram();
+          currentFilename = 'diagram.bpmn';
           fitViewport();
         });
     </script>


### PR DESCRIPTION
## Summary
- provide a button to create a blank allocation-auto.bpmn20.xml diagram
- remember last used file name when saving
- document the new workflow in README and USAGE

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a289f001883339735c89cbb9ca2fa